### PR TITLE
FreeBSD update

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ dependencies are fetched automatically while building.
 
     $ make build
 
+or on FreeBSD
+
+    $ gmake build
+
 Afterwards the binary is created as `bin/signaling`.
 
 

--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 ROOT="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 

--- a/scripts/get_continent_map.py
+++ b/scripts/get_continent_map.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3.7
 #
 # Standalone signaling server for the Nextcloud Spreed app.
 # Copyright (C) 2019 struktur AG
@@ -51,7 +51,7 @@ else:
 
 def generate_map(filename):
   data = subprocess.check_output([
-    '/usr/bin/curl',
+    'curl',
     '-L',
     URL,
   ])


### PR DESCRIPTION
1. run the build with gmake build on FreeBSD (documentation update into README.md)
2. Using env instead of direct interpreter call in head of python script - more flexible use of python scripts (there's no default symlink like python2 or python3 in FreeBSD)
3. removing full path before of 'curl' to be able to run it by the script for dependency downloads